### PR TITLE
Add profile-based work suggestions

### DIFF
--- a/cmd/project_suggest.go
+++ b/cmd/project_suggest.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/maxbeizer/gh-helm/internal/config"
+	"github.com/maxbeizer/gh-helm/internal/github"
+	"github.com/maxbeizer/gh-helm/internal/output"
+	"github.com/maxbeizer/gh-helm/internal/profile"
+	"github.com/spf13/cobra"
+)
+
+var projectSuggestCmd = &cobra.Command{
+	Use:   "suggest",
+	Short: "Suggest issues based on hubber profile",
+	Long:  "Rank available issues by match with the hubber's skills, growth areas, and interests from their profile.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load("helm.toml")
+		if err != nil {
+			return err
+		}
+
+		profileRepo, _ := cmd.Flags().GetString("profile-repo")
+		if profileRepo == "" {
+			return fmt.Errorf("--profile-repo is required (e.g., owner/hubber-1-1)")
+		}
+
+		hubberProfile, err := profile.Load(cmd.Context(), profileRepo)
+		if err != nil {
+			return fmt.Errorf("load profile: %w", err)
+		}
+
+		// Search for open issues with configured label
+		label := "agent-ready"
+		if len(cfg.Filters.Labels) > 0 {
+			label = cfg.Filters.Labels[0]
+		}
+		query := fmt.Sprintf("is:issue is:open label:%s", label)
+		if cfg.Project.Owner != "" {
+			query += " org:" + cfg.Project.Owner
+		}
+
+		searchItems, err := github.SearchIssues(cmd.Context(), query)
+		if err != nil {
+			return fmt.Errorf("search issues: %w", err)
+		}
+
+		issues := make([]profile.IssueSummary, 0, len(searchItems))
+		for _, item := range searchItems {
+			labels := make([]string, 0, len(item.Labels))
+			for _, l := range item.Labels {
+				labels = append(labels, l.Name)
+			}
+			issues = append(issues, profile.IssueSummary{
+				Number: item.Number,
+				Title:  item.Title,
+				Labels: labels,
+				Body:   item.Body,
+			})
+		}
+
+		suggestions := profile.SuggestWork(hubberProfile, issues)
+
+		out := output.New(cmd)
+		return out.Print(suggestions)
+	},
+}
+
+func init() {
+	projectSuggestCmd.Flags().String("profile-repo", "", "1-1 repo containing hubber-profile.toml")
+	projectCmd.AddCommand(projectSuggestCmd)
+}

--- a/hubber-profile.toml.example
+++ b/hubber-profile.toml.example
@@ -1,0 +1,17 @@
+# hubber-profile.toml — place in your 1-1 repo root
+# The project agent reads this to suggest work that matches your skills and growth.
+
+[skills]
+strong = ["go", "typescript", "api-design", "testing"]
+growing = ["rust", "security", "observability"]
+interested = ["ml-ops", "distributed-systems"]
+
+growth-areas = [
+    "Wants more cross-team visibility",
+    "Working toward senior promotion — needs large scope project",
+    "Interested in security work but hasn't had exposure",
+]
+
+[preferences]
+work-style = "Prefers deep focus over breadth"
+challenge-level = "Ready for stretch assignments"

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -1,0 +1,127 @@
+package profile
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/maxbeizer/gh-helm/internal/github"
+)
+
+type HubberProfile struct {
+	Skills      SkillSet    `toml:"skills"`
+	GrowthAreas []string   `toml:"growth-areas"`
+	Preferences Preferences `toml:"preferences"`
+}
+
+type SkillSet struct {
+	Strong     []string `toml:"strong"`
+	Growing    []string `toml:"growing"`
+	Interested []string `toml:"interested"`
+}
+
+type Preferences struct {
+	WorkStyle      string `toml:"work-style"`
+	ChallengeLevel string `toml:"challenge-level"`
+}
+
+type WorkSuggestion struct {
+	IssueNumber int      `json:"issue_number"`
+	IssueTitle  string   `json:"issue_title"`
+	Score       int      `json:"score"`
+	Reasons     []string `json:"reasons"`
+}
+
+type IssueSummary struct {
+	Number int
+	Title  string
+	Labels []string
+	Body   string
+}
+
+// Load fetches a hubber profile from their 1-1 repo.
+// Looks for hubber-profile.toml in the repo root.
+func Load(ctx context.Context, repo string) (HubberProfile, error) {
+	if repo == "" {
+		return HubberProfile{}, fmt.Errorf("profile repo is required")
+	}
+	out, err := github.RunWith(ctx, "api", fmt.Sprintf("repos/%s/contents/hubber-profile.toml", repo),
+		"--jq", ".content", "-H", "Accept: application/vnd.github.raw+json")
+	if err != nil {
+		return HubberProfile{}, fmt.Errorf("fetch profile from %s: %w", repo, err)
+	}
+	var profile HubberProfile
+	if _, err := toml.Decode(string(out), &profile); err != nil {
+		return HubberProfile{}, fmt.Errorf("parse profile: %w", err)
+	}
+	return profile, nil
+}
+
+// SuggestWork scores and ranks issues based on the hubber's profile.
+// Returns suggestions sorted by score (highest first).
+func SuggestWork(profile HubberProfile, issues []IssueSummary) []WorkSuggestion {
+	suggestions := make([]WorkSuggestion, 0, len(issues))
+	for _, issue := range issues {
+		suggestion := scoreIssue(profile, issue)
+		if suggestion.Score > 0 {
+			suggestions = append(suggestions, suggestion)
+		}
+	}
+	// Sort by score descending
+	for i := 0; i < len(suggestions); i++ {
+		for j := i + 1; j < len(suggestions); j++ {
+			if suggestions[j].Score > suggestions[i].Score {
+				suggestions[i], suggestions[j] = suggestions[j], suggestions[i]
+			}
+		}
+	}
+	return suggestions
+}
+
+func scoreIssue(profile HubberProfile, issue IssueSummary) WorkSuggestion {
+	suggestion := WorkSuggestion{
+		IssueNumber: issue.Number,
+		IssueTitle:  issue.Title,
+	}
+
+	text := strings.ToLower(issue.Title + " " + issue.Body)
+	labelSet := map[string]bool{}
+	for _, l := range issue.Labels {
+		labelSet[strings.ToLower(l)] = true
+	}
+
+	// Strong skills: good for fast delivery (score: 2 per match)
+	for _, skill := range profile.Skills.Strong {
+		if containsSkill(text, labelSet, skill) {
+			suggestion.Score += 2
+			suggestion.Reasons = append(suggestion.Reasons, fmt.Sprintf("Matches strong skill: %s", skill))
+		}
+	}
+
+	// Growing skills: stretch opportunity (score: 3 per match — higher because growth)
+	for _, skill := range profile.Skills.Growing {
+		if containsSkill(text, labelSet, skill) {
+			suggestion.Score += 3
+			suggestion.Reasons = append(suggestion.Reasons, fmt.Sprintf("Growth opportunity: %s (growing skill)", skill))
+		}
+	}
+
+	// Interested skills: engagement boost (score: 1 per match)
+	for _, skill := range profile.Skills.Interested {
+		if containsSkill(text, labelSet, skill) {
+			suggestion.Score += 1
+			suggestion.Reasons = append(suggestion.Reasons, fmt.Sprintf("Aligns with interest: %s", skill))
+		}
+	}
+
+	return suggestion
+}
+
+func containsSkill(text string, labels map[string]bool, skill string) bool {
+	lower := strings.ToLower(skill)
+	if labels[lower] {
+		return true
+	}
+	return strings.Contains(text, lower)
+}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,71 @@
+package profile
+
+import (
+	"testing"
+)
+
+func TestSuggestWork(t *testing.T) {
+	p := HubberProfile{
+		Skills: SkillSet{
+			Strong:     []string{"go", "api-design"},
+			Growing:    []string{"security", "observability"},
+			Interested: []string{"ml-ops"},
+		},
+		GrowthAreas: []string{"Wants security exposure"},
+	}
+
+	issues := []IssueSummary{
+		{Number: 55, Title: "Refactor auth middleware", Labels: []string{"security", "go"}, Body: "Security improvements to auth"},
+		{Number: 58, Title: "Add rate limiting", Labels: []string{"go", "api-design"}, Body: "Rate limit the API endpoints"},
+		{Number: 61, Title: "Set up observability pipeline", Labels: []string{"observability"}, Body: "Add monitoring and tracing"},
+		{Number: 62, Title: "Update README", Labels: []string{"documentation"}, Body: "Fix typos in docs"},
+	}
+
+	suggestions := SuggestWork(p, issues)
+
+	if len(suggestions) == 0 {
+		t.Fatal("expected suggestions, got none")
+	}
+
+	// Issue 55 should rank high: go (strong:2) + security (growing:3) = 5
+	// Issue 58: go (strong:2) + api-design (strong:2) = 4
+	// Issue 61: observability (growing:3) = 3
+	// Issue 62: no matches = 0 (filtered out)
+
+	if suggestions[0].IssueNumber != 55 {
+		t.Errorf("top suggestion = #%d, want #55", suggestions[0].IssueNumber)
+	}
+	if len(suggestions) != 3 {
+		t.Errorf("got %d suggestions, want 3 (doc issue should be filtered)", len(suggestions))
+	}
+
+	if len(suggestions[0].Reasons) == 0 {
+		t.Error("top suggestion should have reasons")
+	}
+}
+
+func TestSuggestWorkEmptyProfile(t *testing.T) {
+	p := HubberProfile{}
+	issues := []IssueSummary{
+		{Number: 1, Title: "Something", Body: "Body"},
+	}
+	suggestions := SuggestWork(p, issues)
+	if len(suggestions) != 0 {
+		t.Errorf("empty profile should produce no suggestions, got %d", len(suggestions))
+	}
+}
+
+func TestScoreIssueGrowingSkillsRankHigher(t *testing.T) {
+	p := HubberProfile{
+		Skills: SkillSet{
+			Strong:  []string{"go"},
+			Growing: []string{"go"},
+		},
+	}
+	issue := IssueSummary{Number: 1, Title: "Go refactor", Labels: []string{"go"}, Body: "refactor go code"}
+	suggestion := scoreIssue(p, issue)
+	// strong: 2 + growing: 3 = 5
+	if suggestion.Score != 5 {
+		t.Errorf("score = %d, want 5", suggestion.Score)
+	}
+}


### PR DESCRIPTION
Adds `gh helm project suggest --profile-repo owner/repo` which reads a hubber's profile from their 1-1 repo and ranks available issues by skill match.

**Changes:**
- `internal/profile`: `Load()` fetches `hubber-profile.toml` from a 1-1 repo; `SuggestWork()` scores issues (strong=2, growing=3, interested=1)
- `cmd/project_suggest.go`: new `suggest` subcommand under `project`
- `hubber-profile.toml.example`: template for hubber profiles
- 3 new tests covering scoring, empty profiles, and ranking

Closes #2