### PR TITLE
feat: sot sync, propose from PR, and workflow docs

### DIFF
--- a/cmd/project_sot.go
+++ b/cmd/project_sot.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/maxbeizer/gh-helm/internal/config"
+	gh "github.com/maxbeizer/gh-helm/internal/github"
 	"github.com/maxbeizer/gh-helm/internal/output"
 	"github.com/maxbeizer/gh-helm/internal/sot"
 	"github.com/spf13/cobra"
@@ -30,15 +31,36 @@ var projectSotProposeCmd = &cobra.Command{
 	Use:   "propose",
 	Short: "Propose an update to the source of truth",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		decision, _ := cmd.Flags().GetString("decision")
-		if decision == "" {
-			return errors.New("--decision is required")
-		}
 		cfg, err := config.Load("helm.toml")
 		if err != nil {
 			return err
 		}
+
 		session, _ := cmd.Flags().GetString("session")
+		prNumber, _ := cmd.Flags().GetInt("pr")
+		decision, _ := cmd.Flags().GetString("decision")
+
+		// PR-based proposal: auto-generate from PR context
+		if prNumber > 0 {
+			repo, _ := cmd.Flags().GetString("repo")
+			if repo == "" {
+				repo, err = gh.CurrentRepo(cmd.Context())
+				if err != nil {
+					return err
+				}
+			}
+			proposed, err := sot.ProposeFromPR(cmd.Context(), cfg.SourceOfTruth, repo, prNumber, session)
+			if err != nil {
+				return err
+			}
+			out := output.New(cmd)
+			return out.Print(map[string]string{"proposed": proposed})
+		}
+
+		// Manual proposal: --decision is required
+		if decision == "" {
+			return errors.New("--decision or --pr is required")
+		}
 		if err := sot.Propose(cfg.SourceOfTruth, decision, session, ""); err != nil {
 			return err
 		}
@@ -47,9 +69,42 @@ var projectSotProposeCmd = &cobra.Command{
 	},
 }
 
+var projectSotSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Reconcile SOT with current issue state",
+	Long:  "Cross-references items in the Next Up section with GitHub issue state and removes entries for closed issues.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load("helm.toml")
+		if err != nil {
+			return err
+		}
+		repo, _ := cmd.Flags().GetString("repo")
+		if repo == "" {
+			repo, err = gh.CurrentRepo(cmd.Context())
+			if err != nil {
+				return err
+			}
+		}
+		apply, _ := cmd.Flags().GetBool("apply")
+		result, err := sot.Sync(cmd.Context(), cfg.SourceOfTruth, repo, apply)
+		if err != nil {
+			return err
+		}
+		out := output.New(cmd)
+		return out.Print(result)
+	},
+}
+
 func init() {
 	projectSotProposeCmd.Flags().String("decision", "", "Decision to propose")
 	projectSotProposeCmd.Flags().String("session", "", "Agent session id")
+	projectSotProposeCmd.Flags().Int("pr", 0, "PR number to generate proposal from")
+	projectSotProposeCmd.Flags().String("repo", "", "Repository owner/name")
+
+	projectSotSyncCmd.Flags().String("repo", "", "Repository owner/name")
+	projectSotSyncCmd.Flags().Bool("apply", false, "Apply changes (default is dry-run)")
+
 	projectSotCmd.AddCommand(projectSotProposeCmd)
+	projectSotCmd.AddCommand(projectSotSyncCmd)
 	projectCmd.AddCommand(projectSotCmd)
 }

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,0 +1,72 @@
+# Workflow Guide: helm project start vs planning claim
+
+## Overview
+
+`gh-helm` provides two distinct approaches to issue work. Understanding when to use each — and how they complement each other — prevents confusion and keeps your workflow efficient.
+
+## `helm project start` — Autonomous Agent
+
+**What it does:** Claims an issue, generates an AI code plan, writes code, and opens a draft PR — all autonomously.
+
+**When to use it:**
+- You want the agent to do the coding work end-to-end
+- The issue is well-scoped with clear acceptance criteria
+- You're comfortable reviewing a draft PR rather than writing code yourself
+
+**Example:**
+```bash
+gh helm project start --issue 42
+gh helm project start --issue 42 --codespace  # also spins up a Codespace
+gh helm project start --issue 42 --dry-run    # preview the plan without executing
+```
+
+**What happens:**
+1. Fetches the issue details
+2. Generates a code plan via AI
+3. Creates a branch and writes code
+4. Opens a draft PR linking back to the issue
+5. (Optionally) creates a Codespace on the PR branch
+
+## `planning claim` — Manual Tracking
+
+**What it does:** Marks an issue as claimed for a session so you (or an agent) can track progress manually. The human or a different agent does the actual work.
+
+**When to use it:**
+- You're doing the work yourself and want session tracking
+- The work requires human judgment that the autonomous agent can't handle
+- You're using a different tool (e.g., Copilot in the editor) for code generation
+- You want to claim an issue to prevent others from picking it up
+
+## How They Work Together
+
+The two approaches are complementary, not competing:
+
+| Scenario | Use |
+|----------|-----|
+| Straightforward bug fix with clear repro | `helm project start` |
+| Complex architectural change | `planning claim` + manual work |
+| Documentation update | Either — `helm project start` handles docs well |
+| Issue triage and claiming | `planning claim` to reserve, then decide approach |
+| Fire-and-forget overnight work | `helm project start --codespace` |
+
+### Combined workflow example
+
+1. Use `planning claim` to reserve an issue during triage
+2. Review the issue complexity
+3. If automatable: `helm project start --issue <N>` to hand off to the agent
+4. If not: do the work yourself, using `helm project sot` to track decisions
+
+## SOT and Config: Always Available
+
+Regardless of which approach you use for coding, these commands are always useful:
+
+- `gh helm project sot` — read the Source of Truth document
+- `gh helm project sot propose --decision "..."` — propose a SOT update
+- `gh helm project sot sync` — reconcile SOT with current issue state
+- `gh helm config` — view/manage project configuration
+
+## Summary
+
+- **`helm project start`** = "agent, do this work for me"
+- **`planning claim`** = "I'm working on this, track my progress"
+- Use SOT commands with either workflow to keep documentation current

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -48,6 +48,35 @@ func FetchIssue(ctx context.Context, repo string, number int) (Issue, error) {
 	return issue, nil
 }
 
+// IssueListItem is a lightweight issue representation returned by ListIssues.
+type IssueListItem struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	State  string `json:"state"`
+	URL    string `json:"url"`
+}
+
+// ListIssues returns issues for a repo filtered by state ("open", "closed", or "all").
+func ListIssues(ctx context.Context, repo, state string) ([]IssueListItem, error) {
+	slog.Debug("listing issues", "repo", repo, "state", state)
+	if state == "" {
+		state = "all"
+	}
+	args := []string{"issue", "list", "--state", state, "--json", "number,title,state,url", "--limit", "200"}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := runGh(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list issues: %w", err)
+	}
+	var items []IssueListItem
+	if err := json.Unmarshal(out, &items); err != nil {
+		return nil, fmt.Errorf("parse issue list: %w", err)
+	}
+	return items, nil
+}
+
 func CommentIssue(ctx context.Context, repo string, number int, body string) error {
 	args := []string{"issue", "comment", fmt.Sprint(number), "--body", body}
 	if repo != "" {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+// PR holds pull request metadata.
+type PR struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	State  string `json:"state"`
+	URL    string `json:"url"`
+}
+
+// FetchPR retrieves pull request metadata.
+func FetchPR(ctx context.Context, repo string, number int) (PR, error) {
+	slog.Debug("fetching PR", "repo", repo, "number", number)
+	args := []string{"pr", "view", fmt.Sprint(number), "--json", "number,title,body,state,url"}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := runGh(ctx, args...)
+	if err != nil {
+		return PR{}, fmt.Errorf("fetch PR #%d: %w", number, err)
+	}
+	var pr PR
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return PR{}, fmt.Errorf("parse PR #%d response: %w", number, err)
+	}
+	return pr, nil
+}
+
+// FetchPRDiff retrieves the diff for a pull request.
+func FetchPRDiff(ctx context.Context, repo string, number int) (string, error) {
+	slog.Debug("fetching PR diff", "repo", repo, "number", number)
+	args := []string{"pr", "diff", fmt.Sprint(number)}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := runGh(ctx, args...)
+	if err != nil {
+		return "", fmt.Errorf("fetch PR #%d diff: %w", number, err)
+	}
+	return string(bytes.TrimSpace(out)), nil
+}
+
+// FetchPRClosingIssues returns issue numbers that a PR will close on merge.
+func FetchPRClosingIssues(ctx context.Context, repo string, number int) ([]int, error) {
+	slog.Debug("fetching PR closing issues", "repo", repo, "number", number)
+	args := []string{"pr", "view", fmt.Sprint(number), "--json", "closingIssuesReferences", "--jq", ".[\"closingIssuesReferences\"].[].number"}
+	if repo != "" {
+		args = append(args, "--repo", repo)
+	}
+	out, err := runGh(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("fetch PR #%d closing issues: %w", number, err)
+	}
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	var numbers []int
+	for _, line := range bytes.Split(trimmed, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(string(line), "%d", &n); err == nil {
+			numbers = append(numbers, n)
+		}
+	}
+	return numbers, nil
+}

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -1,0 +1,125 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestListIssues(t *testing.T) {
+	withMockGh(t, func(_ context.Context, args ...string) ([]byte, error) {
+		// Verify state flag is passed
+		hasState := false
+		for _, a := range args {
+			if a == "--state" {
+				hasState = true
+			}
+		}
+		if !hasState {
+			return nil, fmt.Errorf("expected --state flag")
+		}
+		resp := []IssueListItem{
+			{Number: 1, Title: "Open issue", State: "OPEN", URL: "https://github.com/org/repo/issues/1"},
+			{Number: 2, Title: "Closed issue", State: "CLOSED", URL: "https://github.com/org/repo/issues/2"},
+		}
+		return json.Marshal(resp)
+	})
+
+	items, err := ListIssues(context.Background(), "org/repo", "all")
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("got %d items, want 2", len(items))
+	}
+	if items[0].Number != 1 {
+		t.Errorf("first item number = %d, want 1", items[0].Number)
+	}
+}
+
+func TestListIssues_DefaultState(t *testing.T) {
+	withMockGh(t, func(_ context.Context, args ...string) ([]byte, error) {
+		for i, a := range args {
+			if a == "--state" && i+1 < len(args) && args[i+1] == "all" {
+				return json.Marshal([]IssueListItem{})
+			}
+		}
+		return nil, fmt.Errorf("expected --state all")
+	})
+
+	_, err := ListIssues(context.Background(), "org/repo", "")
+	if err != nil {
+		t.Fatalf("ListIssues with empty state: %v", err)
+	}
+}
+
+func TestFetchPR(t *testing.T) {
+	withMockGh(t, func(_ context.Context, _ ...string) ([]byte, error) {
+		resp := PR{
+			Number: 10,
+			Title:  "Add auth feature",
+			Body:   "Implements auth\n\nCloses #5",
+			State:  "OPEN",
+			URL:    "https://github.com/org/repo/pull/10",
+		}
+		return json.Marshal(resp)
+	})
+
+	pr, err := FetchPR(context.Background(), "org/repo", 10)
+	if err != nil {
+		t.Fatalf("FetchPR: %v", err)
+	}
+	if pr.Number != 10 {
+		t.Errorf("Number = %d, want 10", pr.Number)
+	}
+	if pr.Title != "Add auth feature" {
+		t.Errorf("Title = %q, want %q", pr.Title, "Add auth feature")
+	}
+}
+
+func TestFetchPRDiff(t *testing.T) {
+	expectedDiff := "diff --git a/foo.go b/foo.go\n+new line"
+	withMockGh(t, func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte(expectedDiff + "\n"), nil
+	})
+
+	diff, err := FetchPRDiff(context.Background(), "org/repo", 10)
+	if err != nil {
+		t.Fatalf("FetchPRDiff: %v", err)
+	}
+	if diff != expectedDiff {
+		t.Errorf("diff = %q, want %q", diff, expectedDiff)
+	}
+}
+
+func TestFetchPRClosingIssues(t *testing.T) {
+	withMockGh(t, func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte("5\n12\n"), nil
+	})
+
+	numbers, err := FetchPRClosingIssues(context.Background(), "org/repo", 10)
+	if err != nil {
+		t.Fatalf("FetchPRClosingIssues: %v", err)
+	}
+	if len(numbers) != 2 {
+		t.Fatalf("got %d numbers, want 2", len(numbers))
+	}
+	if numbers[0] != 5 || numbers[1] != 12 {
+		t.Errorf("numbers = %v, want [5 12]", numbers)
+	}
+}
+
+func TestFetchPRClosingIssues_Empty(t *testing.T) {
+	withMockGh(t, func(_ context.Context, _ ...string) ([]byte, error) {
+		return []byte(""), nil
+	})
+
+	numbers, err := FetchPRClosingIssues(context.Background(), "org/repo", 10)
+	if err != nil {
+		t.Fatalf("FetchPRClosingIssues: %v", err)
+	}
+	if numbers != nil {
+		t.Errorf("expected nil, got %v", numbers)
+	}
+}

--- a/internal/sot/propose.go
+++ b/internal/sot/propose.go
@@ -1,0 +1,108 @@
+package sot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gh "github.com/maxbeizer/gh-helm/internal/github"
+)
+
+// ProposeFromPR generates a SOT update proposal based on a PR's metadata and diff.
+func ProposeFromPR(ctx context.Context, path, repo string, prNumber int, session string) (string, error) {
+	pr, err := gh.FetchPR(ctx, repo, prNumber)
+	if err != nil {
+		return "", fmt.Errorf("fetch PR: %w", err)
+	}
+
+	diff, err := gh.FetchPRDiff(ctx, repo, prNumber)
+	if err != nil {
+		return "", fmt.Errorf("fetch PR diff: %w", err)
+	}
+
+	closingIssues, err := gh.FetchPRClosingIssues(ctx, repo, prNumber)
+	if err != nil {
+		// Non-fatal — we can still propose without closing issue info
+		closingIssues = nil
+	}
+
+	decision := buildProposal(pr, diff, closingIssues)
+
+	if err := Propose(path, decision, session, fmt.Sprintf("#%d", prNumber)); err != nil {
+		return "", err
+	}
+
+	return decision, nil
+}
+
+func buildProposal(pr gh.PR, diff string, closingIssues []int) string {
+	var parts []string
+
+	parts = append(parts, fmt.Sprintf("PR #%d: %s", pr.Number, pr.Title))
+
+	if len(closingIssues) > 0 {
+		var refs []string
+		for _, n := range closingIssues {
+			refs = append(refs, fmt.Sprintf("#%d", n))
+		}
+		parts = append(parts, fmt.Sprintf("Closes: %s", strings.Join(refs, ", ")))
+	}
+
+	changes := summarizeDiff(diff)
+	if len(changes) > 0 {
+		parts = append(parts, "Changes: "+strings.Join(changes, "; "))
+	}
+
+	return strings.Join(parts, ". ")
+}
+
+// summarizeDiff extracts a high-level summary of what files/packages changed.
+func summarizeDiff(diff string) []string {
+	seen := make(map[string]bool)
+	var changes []string
+
+	for _, line := range strings.Split(diff, "\n") {
+		if !strings.HasPrefix(line, "diff --git") {
+			continue
+		}
+		// Extract b/path from "diff --git a/foo b/foo"
+		parts := strings.Fields(line)
+		if len(parts) < 4 {
+			continue
+		}
+		file := strings.TrimPrefix(parts[3], "b/")
+		dir := categorizeFile(file)
+		if !seen[dir] {
+			seen[dir] = true
+			changes = append(changes, dir)
+		}
+	}
+
+	return changes
+}
+
+func categorizeFile(path string) string {
+	parts := strings.Split(path, "/")
+	switch {
+	case strings.HasPrefix(path, "cmd/"):
+		return "CLI commands"
+	case strings.HasPrefix(path, "internal/sot/"):
+		return "SOT logic"
+	case strings.HasPrefix(path, "internal/github/"):
+		return "GitHub API layer"
+	case strings.HasPrefix(path, "internal/agent/"):
+		return "project agent"
+	case strings.HasPrefix(path, "internal/manager/"):
+		return "manager agent"
+	case strings.HasPrefix(path, "internal/config/"):
+		return "configuration"
+	case strings.HasPrefix(path, "docs/"):
+		return "documentation"
+	case strings.HasSuffix(path, "_test.go"):
+		return "tests"
+	case len(parts) >= 2 && parts[0] == "internal":
+		return parts[1] + " package"
+	default:
+		return path
+	}
+}

--- a/internal/sot/propose_test.go
+++ b/internal/sot/propose_test.go
@@ -1,0 +1,166 @@
+package sot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPropose_Basic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOT.md")
+	if err := os.WriteFile(path, []byte("# SOT\n\nSome content.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Propose(path, "Added new feature X", "sess-123", "")
+	if err != nil {
+		t.Fatalf("Propose: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	if !strings.Contains(content, "## Proposed Updates") {
+		t.Error("expected Proposed Updates section")
+	}
+	if !strings.Contains(content, "Added new feature X") {
+		t.Error("expected decision text")
+	}
+	if !strings.Contains(content, "sess-123") {
+		t.Error("expected session id")
+	}
+	if !strings.Contains(content, "Pending human review") {
+		t.Error("expected pending review marker")
+	}
+}
+
+func TestPropose_WithPR(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOT.md")
+	if err := os.WriteFile(path, []byte("# SOT\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Propose(path, "Fixed bug Y", "sess-456", "#42")
+	if err != nil {
+		t.Fatalf("Propose: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	if !strings.Contains(content, "Based on work in PR #42") {
+		t.Error("expected PR reference")
+	}
+}
+
+func TestPropose_AppendsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOT.md")
+	initial := "# SOT\n\n## Proposed Updates\n\n> Existing proposal\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Propose(path, "Second proposal", "sess-789", "")
+	if err != nil {
+		t.Fatalf("Propose: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+
+	if !strings.Contains(content, "Existing proposal") {
+		t.Error("expected existing proposal to remain")
+	}
+	if !strings.Contains(content, "Second proposal") {
+		t.Error("expected new proposal")
+	}
+}
+
+func TestRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "SOT.md")
+	expected := "# Test SOT\n\nContent here.\n"
+	if err := os.WriteFile(path, []byte(expected), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != expected {
+		t.Errorf("Read = %q, want %q", got, expected)
+	}
+}
+
+func TestRead_NotFound(t *testing.T) {
+	_, err := Read("/nonexistent/path/SOT.md")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestSummarizeDiff(t *testing.T) {
+	diff := `diff --git a/cmd/project_sot.go b/cmd/project_sot.go
+index abc..def 100644
+--- a/cmd/project_sot.go
++++ b/cmd/project_sot.go
+@@ -1,5 +1,10 @@
+ some content
+diff --git a/internal/sot/sync.go b/internal/sot/sync.go
+index abc..def 100644
+--- a/internal/sot/sync.go
++++ b/internal/sot/sync.go
+@@ -1,3 +1,8 @@
+ some content
+diff --git a/docs/WORKFLOW.md b/docs/WORKFLOW.md
+new file mode 100644
+--- /dev/null
++++ b/docs/WORKFLOW.md
+@@ -0,0 +1,5 @@
+ some content`
+
+	changes := summarizeDiff(diff)
+	if len(changes) != 3 {
+		t.Fatalf("expected 3 categories, got %d: %v", len(changes), changes)
+	}
+
+	expected := map[string]bool{
+		"CLI commands":  true,
+		"SOT logic":     true,
+		"documentation": true,
+	}
+	for _, c := range changes {
+		if !expected[c] {
+			t.Errorf("unexpected category: %s", c)
+		}
+	}
+}
+
+func TestCategorizeFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"cmd/root.go", "CLI commands"},
+		{"internal/sot/sync.go", "SOT logic"},
+		{"internal/github/pr.go", "GitHub API layer"},
+		{"internal/agent/start.go", "project agent"},
+		{"internal/manager/observe.go", "manager agent"},
+		{"internal/config/project.go", "configuration"},
+		{"docs/WORKFLOW.md", "documentation"},
+		{"internal/foo/bar_test.go", "tests"},
+		{"internal/pillars/map.go", "pillars package"},
+		{"go.mod", "go.mod"},
+	}
+	for _, tt := range tests {
+		got := categorizeFile(tt.path)
+		if got != tt.want {
+			t.Errorf("categorizeFile(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/internal/sot/sync.go
+++ b/internal/sot/sync.go
@@ -1,0 +1,142 @@
+package sot
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	gh "github.com/maxbeizer/gh-helm/internal/github"
+	"github.com/maxbeizer/gh-helm/internal/state"
+)
+
+// SyncResult describes changes found by syncing the SOT with issue state.
+type SyncResult struct {
+	Removed []string `json:"removed"`
+	Kept    []string `json:"kept"`
+	Summary string   `json:"summary"`
+}
+
+// Sync reads the SOT file, cross-references items referencing issues with
+// actual issue state, and returns what should change. If apply is true,
+// the SOT file is rewritten with completed items removed from "Next Up".
+func Sync(ctx context.Context, path, repo string, apply bool) (SyncResult, error) {
+	content, err := Read(path)
+	if err != nil {
+		return SyncResult{}, err
+	}
+
+	closedIssues, err := fetchClosedIssueNumbers(ctx, repo)
+	if err != nil {
+		return SyncResult{}, fmt.Errorf("fetch closed issues: %w", err)
+	}
+
+	newContent, result := reconcile(content, closedIssues)
+
+	if apply && len(result.Removed) > 0 {
+		if err := writeAtomic(path, newContent); err != nil {
+			return SyncResult{}, fmt.Errorf("write SOT: %w", err)
+		}
+	}
+
+	return result, nil
+}
+
+// issueRefPattern matches #N issue references in markdown lines.
+var issueRefPattern = regexp.MustCompile(`#(\d+)`)
+
+// reconcile processes the SOT content, removing lines from "Next Up" that
+// reference closed issues. It also moves completed items to "Outcomes".
+func reconcile(content string, closedIssues map[int]bool) (string, SyncResult) {
+	lines := strings.Split(content, "\n")
+	var result SyncResult
+	var output []string
+
+	inNextUp := false
+	var outcomesInsertIdx int
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Track which section we're in
+		if strings.HasPrefix(trimmed, "## ") {
+			if trimmed == "## Next Up" {
+				inNextUp = true
+				output = append(output, line)
+				continue
+			}
+			if trimmed == "## Outcomes" {
+				outcomesInsertIdx = len(output) + 1
+			}
+			inNextUp = false
+		}
+
+		if inNextUp && (strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ")) {
+			refs := issueRefPattern.FindAllStringSubmatch(trimmed, -1)
+			removed := false
+			for _, ref := range refs {
+				num, _ := strconv.Atoi(ref[1])
+				if closedIssues[num] {
+					result.Removed = append(result.Removed, fmt.Sprintf("Removed: %s (issue #%d closed)", trimmed, num))
+					removed = true
+					break
+				}
+			}
+			if removed {
+				_ = i // line skipped from output
+				continue
+			}
+			result.Kept = append(result.Kept, trimmed)
+		}
+
+		output = append(output, line)
+	}
+
+	// If we found an outcomes section and removed items, add them as completed
+	if outcomesInsertIdx > 0 && len(result.Removed) > 0 {
+		var newOutcomes []string
+		for _, r := range result.Removed {
+			// Extract the item text from "Removed: - item text (issue #N closed)"
+			text := strings.TrimPrefix(r, "Removed: ")
+			if idx := strings.LastIndex(text, " (issue #"); idx > 0 {
+				text = text[:idx]
+			}
+			// Convert "- item" to "- [x] item"
+			text = strings.TrimPrefix(text, "- ")
+			text = strings.TrimPrefix(text, "* ")
+			newOutcomes = append(newOutcomes, "- [x] "+text)
+		}
+
+		// Insert after the ## Outcomes line
+		before := output[:outcomesInsertIdx]
+		after := output[outcomesInsertIdx:]
+		output = append(before, newOutcomes...)
+		output = append(output, after...)
+	}
+
+	switch len(result.Removed) {
+	case 0:
+		result.Summary = "SOT is up to date — no completed items found in Next Up"
+	default:
+		result.Summary = fmt.Sprintf("Found %d completed item(s) in Next Up referencing closed issues", len(result.Removed))
+	}
+
+	return strings.Join(output, "\n"), result
+}
+
+func writeAtomic(path, content string) error {
+	return state.WriteAtomic(path, []byte(content), 0o644)
+}
+
+func fetchClosedIssueNumbers(ctx context.Context, repo string) (map[int]bool, error) {
+	issues, err := gh.ListIssues(ctx, repo, "closed")
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[int]bool, len(issues))
+	for _, iss := range issues {
+		m[iss.Number] = true
+	}
+	return m, nil
+}

--- a/internal/sot/sync_test.go
+++ b/internal/sot/sync_test.go
@@ -1,0 +1,181 @@
+package sot
+
+import (
+	"testing"
+)
+
+func TestReconcile_NoIssueRefs(t *testing.T) {
+	content := `# SOT
+
+## Next Up
+
+- AI-powered pillar inference
+- Manager agent learning
+`
+	closed := map[int]bool{1: true, 2: true}
+	_, result := reconcile(content, closed)
+
+	if len(result.Removed) != 0 {
+		t.Errorf("expected 0 removed, got %d", len(result.Removed))
+	}
+	if len(result.Kept) != 2 {
+		t.Errorf("expected 2 kept, got %d", len(result.Kept))
+	}
+}
+
+func TestReconcile_RemovesClosedIssues(t *testing.T) {
+	content := `# SOT
+
+## Outcomes
+
+- [x] Existing outcome
+
+## Next Up
+
+- Fix auth bug (#42)
+- AI-powered pillar inference
+- Add dashboard (#99)
+`
+	closed := map[int]bool{42: true}
+	newContent, result := reconcile(content, closed)
+
+	if len(result.Removed) != 1 {
+		t.Fatalf("expected 1 removed, got %d", len(result.Removed))
+	}
+	if len(result.Kept) != 2 {
+		t.Errorf("expected 2 kept, got %d: %v", len(result.Kept), result.Kept)
+	}
+
+	// Check that the closed item was moved to outcomes
+	if !contains(newContent, "- [x] Fix auth bug (#42)") {
+		t.Error("expected closed item to appear in outcomes")
+	}
+	// Check that the item was removed from Next Up section
+	lines := splitLines(newContent)
+	inNextUp := false
+	for _, line := range lines {
+		trimmed := trimSpace(line)
+		if trimmed == "## Next Up" {
+			inNextUp = true
+			continue
+		}
+		if len(trimmed) > 0 && trimmed[:1] == "#" {
+			inNextUp = false
+		}
+		if inNextUp && contains(line, "#42") {
+			t.Error("issue #42 should not remain in Next Up")
+		}
+	}
+}
+
+func TestReconcile_AllClosed(t *testing.T) {
+	content := `# SOT
+
+## Next Up
+
+- Item one (#1)
+- Item two (#2)
+`
+	closed := map[int]bool{1: true, 2: true}
+	_, result := reconcile(content, closed)
+
+	if len(result.Removed) != 2 {
+		t.Errorf("expected 2 removed, got %d", len(result.Removed))
+	}
+	if len(result.Kept) != 0 {
+		t.Errorf("expected 0 kept, got %d", len(result.Kept))
+	}
+}
+
+func TestReconcile_NoClosed(t *testing.T) {
+	content := `# SOT
+
+## Next Up
+
+- Open item (#5)
+- Another open (#6)
+`
+	closed := map[int]bool{}
+	_, result := reconcile(content, closed)
+
+	if len(result.Removed) != 0 {
+		t.Errorf("expected 0 removed, got %d", len(result.Removed))
+	}
+	if result.Summary != "SOT is up to date — no completed items found in Next Up" {
+		t.Errorf("unexpected summary: %s", result.Summary)
+	}
+}
+
+func TestReconcile_MultipleIssueRefsOneLine(t *testing.T) {
+	content := `# SOT
+
+## Next Up
+
+- Combine #3 and #4 into one
+`
+	closed := map[int]bool{3: true}
+	_, result := reconcile(content, closed)
+
+	if len(result.Removed) != 1 {
+		t.Errorf("expected 1 removed, got %d", len(result.Removed))
+	}
+}
+
+func TestReconcile_AsteriskBullets(t *testing.T) {
+	content := `# SOT
+
+## Next Up
+
+* Done item (#10)
+* Open item
+`
+	closed := map[int]bool{10: true}
+	_, result := reconcile(content, closed)
+
+	if len(result.Removed) != 1 {
+		t.Errorf("expected 1 removed, got %d", len(result.Removed))
+	}
+	if len(result.Kept) != 1 {
+		t.Errorf("expected 1 kept, got %d", len(result.Kept))
+	}
+}
+
+// helpers
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+func trimSpace(s string) string {
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}


### PR DESCRIPTION
## Summary

Adds three new capabilities to `helm project sot`:

### Issue #13: Workflow documentation
- New `docs/WORKFLOW.md` clarifying when to use `helm project start` (autonomous agent) vs `planning claim` (manual tracking) and how they complement each other.

### Issue #14: `helm project sot sync`
- New subcommand that reconciles the SOT "Next Up" section with GitHub issue state
- Removes items referencing closed issues and moves them to "Outcomes"
- Dry-run by default, `--apply` to write changes
- `--repo` flag to specify repository (defaults to current)

### Issue #15: `helm project sot propose --pr <number>`
- Enhanced `propose` subcommand now accepts `--pr` flag
- Auto-generates SOT update proposals from PR context (title, diff summary, closing issues)
- Complements existing `--decision` flag for manual proposals

### New internal code
- `internal/sot/sync.go` — reconciliation logic
- `internal/sot/propose.go` — PR-based proposal generation
- `internal/github/pr.go` — `FetchPR`, `FetchPRDiff`, `FetchPRClosingIssues`
- `internal/github/issues.go` — `ListIssues` for bulk queries

All new code has tests. Build, vet, and tests pass.

Closes #13
Closes #14
Closes #15