### PR TITLE
chore: sync .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,13 +1,23 @@
-project_name: gh-helm
+project_name: gh-extension-template
+
 builds:
-  - binary: gh-helm
-    goos: [darwin, linux, windows]
-    goarch: [amd64, arm64]
-    ldflags: [-s, -w]
+  - binary: gh-extension-template
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+
 archives:
   - format: binary
     name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}"
+
 release:
   prerelease: auto
+
 changelog:
   sort: asc


### PR DESCRIPTION
Automated sync from [gh-fleet](https://github.com/maxbeizer/gh-fleet) canonical files.

File: `.goreleaser.yml`